### PR TITLE
Implement NoOpDistributedLockManager for when locking is disabled

### DIFF
--- a/fhir-odoo-app/src/main/resources/application.properties
+++ b/fhir-odoo-app/src/main/resources/application.properties
@@ -8,6 +8,3 @@
 
 # Import fhir-odoo module configuration
 spring.config.import=fhir-odoo.properties
-
-# The external identifier for the categ_products_drug_orders
-odoo.drugs.category.ext.id=${EIP_ODOO_DRUGS_CATEGORY_EXT_ID}

--- a/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/LockAutoConfiguration.java
+++ b/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/LockAutoConfiguration.java
@@ -7,6 +7,7 @@
  */
 package com.ozonehis.fhir.odoo.lock;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,39 +16,70 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
- * Spring configuration that wires the Redis-backed distributed lock subsystem.
- * <p>All lock beans are created here rather than via {@code @Component} annotations so that
- * the dependency graph is explicit, testable, and disabled as a unit when {@code fhir.odoo.lock.redis.enabled=false}.
- * <p>The entire subsystem is skipped when {@code fhir.odoo.lock.redis.enabled=false}, allowing
- * tests or environments without Redis to opt out cleanly.
+ * Top-level lock configuration — always active.
+ *
+ * <p>Property binding is enabled here so {@link RedisLockProperties} is available regardless of
+ * whether Redis locking is enabled. The Redis-specific beans live in the nested
+ * {@link RedisLockConfiguration} class which is only activated when
+ * {@code fhir.odoo.lock.redis.enabled=true}. When that condition is false the
+ * {@link NoOpDistributedLockManager} fallback is registered instead, ensuring the application
+ * context always contains exactly one {@link DistributedLockManager} bean.
  */
 @Configuration
 @EnableConfigurationProperties(RedisLockProperties.class)
-@ConditionalOnProperty(name = "fhir.odoo.lock.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class LockAutoConfiguration {
 
     /**
-     * Creates the {@link RedisHealthMonitor}, which performs the Redis startup wait via
-     * {@link jakarta.annotation.PostConstruct} and runs the ongoing background probe.
-     * <p>This bean is declared first so that it is fully initialized (and startup wait has
-     * completed) before the {@link DistributedLockManager} bean that depends on it is created.
+     * Fallback {@link DistributedLockManager} registered when Redis locking is disabled
+     * ({@code fhir.odoo.lock.redis.enabled=false}, the default).
+     *
+     * <p>Executes actions directly — no lock is acquired, no Redis connection is required.
+     * This allows the application to start without Redis. A WARN is logged at startup to
+     * make it explicit that mutual exclusion is not enforced.
+     *
+     * <p>This bean is skipped automatically when {@link RedisLockConfiguration} registers a
+     * Redis-backed {@link DistributedLockManager} first.
      */
     @Bean
-    public RedisHealthMonitor redisHealthMonitor(
-            RedisConnectionFactory connectionFactory, RedisLockProperties properties) {
-        return new RedisHealthMonitor(connectionFactory, properties);
+    @ConditionalOnMissingBean(DistributedLockManager.class)
+    public DistributedLockManager noOpDistributedLockManager() {
+        return new NoOpDistributedLockManager();
     }
 
     /**
-     * Creates the {@link DistributedLockManager} backed by Redis.
-     * <p>Depends on {@link RedisHealthMonitor} being fully initialized, which guarantees Redis is
-     * reachable before any lock operation is ever attempted.
+     * Nested configuration activated only when {@code fhir.odoo.lock.redis.enabled=true}.
+     *
+     * <p>Declares the {@link RedisHealthMonitor} (which blocks at {@link jakarta.annotation.PostConstruct} until
+     * Redis is reachable or the startup timeout elapses) and the Redis-backed
+     * {@link DistributedLockManager}. Because these beans are registered before the outer-class
+     * {@link #noOpDistributedLockManager()} is evaluated, the {@code @ConditionalOnMissingBean}
+     * fallback is correctly suppressed.
      */
-    @Bean
-    public DistributedLockManager distributedLockManager(
-            StringRedisTemplate stringRedisTemplate,
-            RedisLockProperties properties,
-            RedisHealthMonitor redisHealthMonitor) {
-        return new RedisDistributedLockManager(stringRedisTemplate, properties, redisHealthMonitor);
+    @Configuration
+    @ConditionalOnProperty(name = "fhir.odoo.lock.redis.enabled", havingValue = "true")
+    static class RedisLockConfiguration {
+
+        /**
+         * Creates the {@link RedisHealthMonitor}, which performs the Redis startup wait and runs
+         * the ongoing background probe. Declared before the lock manager to ensure Redis is
+         * reachable before any lock operation is ever attempted.
+         */
+        @Bean
+        public RedisHealthMonitor redisHealthMonitor(
+                RedisConnectionFactory connectionFactory, RedisLockProperties properties) {
+            return new RedisHealthMonitor(connectionFactory, properties);
+        }
+
+        /**
+         * Creates the {@link DistributedLockManager} backed by Redis. Depends on
+         * {@link RedisHealthMonitor} being fully initialized.
+         */
+        @Bean
+        public DistributedLockManager distributedLockManager(
+                StringRedisTemplate stringRedisTemplate,
+                RedisLockProperties properties,
+                RedisHealthMonitor redisHealthMonitor) {
+            return new RedisDistributedLockManager(stringRedisTemplate, properties, redisHealthMonitor);
+        }
     }
 }

--- a/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/NoOpDistributedLockManager.java
+++ b/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/NoOpDistributedLockManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2024, Ozone HIS <info@ozone-his.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.ozonehis.fhir.odoo.lock;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * No-operation {@link DistributedLockManager} registered automatically when Redis locking is
+ * disabled ({@code fhir.odoo.lock.redis.enabled=false}).
+ *
+ * <p>Actions are executed directly — no lock is acquired, no Redis connection is required.
+ * This allows the application to start and operate without Redis in environments where distributed
+ * mutual exclusion is not needed. To enable real locking, set
+ * {@code fhir.odoo.lock.redis.enabled=true}.
+ *
+ * <p><strong>Warning:</strong> this implementation provides <em>no</em> mutual exclusion. It must
+ * not be used in multi-instance deployments where concurrent access to shared resources must be
+ * serialized.
+ */
+@Slf4j
+public class NoOpDistributedLockManager implements DistributedLockManager {
+
+    public NoOpDistributedLockManager() {
+        log.warn(
+                "Redis distributed locking is DISABLED. Actions will execute without any mutual exclusion. "
+                        + "Set fhir.odoo.lock.redis.enabled=true to enable Redis-backed locking.");
+    }
+
+    @Override
+    public <T> T executeWithLock(LockPurpose purpose, String lockKey, Supplier<T> action) {
+        log.debug("NoOp lock: executing action for purpose={} key={} without acquiring a lock", purpose, lockKey);
+        return action.get();
+    }
+
+    @Override
+    public <T> Optional<T> tryWithLock(LockPurpose purpose, String lockKey, Supplier<T> action) {
+        log.debug("NoOp lock: executing tryWithLock action for purpose={} key={} without acquiring a lock", purpose, lockKey);
+        return Optional.ofNullable(action.get());
+    }
+}

--- a/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/NoOpDistributedLockManager.java
+++ b/fhir-odoo/src/main/java/com/ozonehis/fhir/odoo/lock/NoOpDistributedLockManager.java
@@ -28,9 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 public class NoOpDistributedLockManager implements DistributedLockManager {
 
     public NoOpDistributedLockManager() {
-        log.warn(
-                "Redis distributed locking is DISABLED. Actions will execute without any mutual exclusion. "
-                        + "Set fhir.odoo.lock.redis.enabled=true to enable Redis-backed locking.");
+        log.warn("Redis distributed locking is DISABLED. Actions will execute without any mutual exclusion. "
+                + "Set fhir.odoo.lock.redis.enabled=true to enable Redis-backed locking.");
     }
 
     @Override
@@ -41,7 +40,10 @@ public class NoOpDistributedLockManager implements DistributedLockManager {
 
     @Override
     public <T> Optional<T> tryWithLock(LockPurpose purpose, String lockKey, Supplier<T> action) {
-        log.debug("NoOp lock: executing tryWithLock action for purpose={} key={} without acquiring a lock", purpose, lockKey);
+        log.debug(
+                "NoOp lock: executing tryWithLock action for purpose={} key={} without acquiring a lock",
+                purpose,
+                lockKey);
         return Optional.ofNullable(action.get());
     }
 }

--- a/fhir-odoo/src/main/resources/fhir-odoo.properties
+++ b/fhir-odoo/src/main/resources/fhir-odoo.properties
@@ -25,7 +25,9 @@ spring.data.redis.password=${REDIS_PASSWORD:}
 # Distributed lock subsystem — Redis
 # ---------------------------------------------------------------------------
 
-# Master switch. Set to false to disable Redis locking entirely (e.g. in environments without Redis).
+# Master switch. Explicitly set to true to enable Redis-backed distributed locking.
+# When false (the default) a no-op lock manager is used: actions run without mutual exclusion.
+# Requires Redis connection settings below to also be correctly configured.
 fhir.odoo.lock.redis.enabled=${FHIR_ODOO_LOCK_REDIS_ENABLED:false}
 
 # Startup: how long to wait for Redis before aborting application boot (ms).
@@ -50,3 +52,6 @@ fhir.odoo.lock.redis.purposes[SERVICE_REQUEST_REQUISITION].key-prefix=${FHIR_ODO
 odoo.partner.dob.field=${ODOO_PARTNER_DOB_FIELD:x_customer_dob}
 odoo.partner.id.field=${ODOO_PARTNER_ID_FIELD:x_external_identifier}
 odoo.partner.weight.field=${ODOO_PARTNER_WEIGHT_FIELD:x_customer_weight}
+
+# The external identifier for the categ_products_drug_orders
+odoo.drugs.category.ext.id=${EIP_ODOO_DRUGS_CATEGORY_EXT_ID:-drugs}


### PR DESCRIPTION
This PR implements `NoOpDistributedLockManager` as a pass-through fallback registered via `@ConditionalOnMissingBean` for when locking is disable.